### PR TITLE
logout controller has a bug when destroying the session

### DIFF
--- a/client/src/components/Logout.jsx
+++ b/client/src/components/Logout.jsx
@@ -5,10 +5,11 @@ export default function Logout(){
 
     async function handleClick(){
         try{
-            const response = await axios.get('https://localhost:5173/logout')
+            console.log('click logout')
+            const response = await axios.post('http://localhost:5000/logout')
             console.log(response)
         }catch(err){
-            console.error(err.response.data.message)
+            console.error(err)
         }
     }
 

--- a/server/config/passport.js
+++ b/server/config/passport.js
@@ -32,7 +32,13 @@ module.exports = function (passport) {
     done(null, user.id)
   });
 
-  passport.deserializeUser((id, done) => {
-    User.findById(id, (err, user) => done(err, user))
+  passport.deserializeUser( async (id, done) => {
+    try{
+      const user = await User.findById(id)
+      done(null, user)
+    }catch(err){
+      done(err)
+    }
+    
   })
 }

--- a/server/controller/authController.js
+++ b/server/controller/authController.js
@@ -2,47 +2,71 @@ const passport = require('passport')
 const User = require('../model/user.js')
 
 module.exports = {
-    postSignup: async (req, res, next) => {
-        try {
-            const { username, email, password } = req.body
-            const existingUser = await User.findOne({email: email}).exec()
+  postSignup: async (req, res, next) => {
+      try {
+          const { username, email, password } = req.body
+          const existingUser = await User.findOne({email: email}).exec()
 
-            if(existingUser){
-                res.send('User already exists')
-                return
-            }
-            if(!existingUser){
-                const user = new User({ username, email, password })                
-                await user.save()
-                res.send('User created')
-            }
-        }catch(err){
-            next(err)
-        }
-    },
-    postLogin: async (req, res, next) => {
-        try{
-            passport.authenticate("local", (err, user, info) => {
+          if(existingUser){
+              res.send('User already exists')
+              return
+          }
+          if(!existingUser){
+              const user = new User({ username, email, password })                
+              await user.save()
+              res.send('User created')
+          }
+      }catch(err){
+          next(err)
+      }
+  },
+  postLogin: async (req, res, next) => {
+      try{
+          passport.authenticate("local", (err, user, info) => {
+              if (err) {
+                return next(err);
+              }
+              if (!user) {
+                res.send('Email does not exist')
+                return next()
+              }
+              req.login(user, (err) => {
                 if (err) {
                   return next(err);
-                }
-                if (!user) {
-                  res.send('Email does not exist')
-                  return next()
-                }
-                req.login(user, (err) => {
-                  if (err) {
-                    return next(err);
-                  } 
-                  res.send("Success! You are logged in.");
-                });
-              })(req, res, next);
-        }catch(err){
-          console.log(err)
-        }
-    },
-    postLogout: async (req, res) => {
-        console.log(req)
-        res.status(200).send('Signup Successful')
-    },
+                } 
+                res.send("Success! You are logged in.");
+              });
+            })(req, res, next);
+      }catch(err){
+        console.log(err)
+      }
+  },
+  postLogout: (req, res) => {
+    // console.log(req)
+    // res.send('hey back')
+    console.log('inside logout')
+    console.log('before logout - req.session:', req.session)
+    try{
+      req.logout(() => {
+        console.log('User has logged out')
+        console.log('after logout - req.session:', req.session)
+      
+        req.session.destroy((err) => {
+          if(err){
+            console.log('Error: Failed to destory the session during logout', err)
+          }
+          req.user = null
+
+          res.status(200).send('User logged out')
+
+        })
+      })
+
+    }catch(err){
+      console.error('error during logout:', err)
+      res.status(500).send('Internal Server Error')
+    }
+  }
 }
+
+

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -17,7 +17,7 @@
         "express-session": "^1.17.3",
         "mongodb": "^6.3.0",
         "mongoose": "^8.0.2",
-        "passport": "^0.7.0",
+        "passport": "^0.5.3",
         "passport-local": "^1.0.0",
         "passport-local-mongoose": "^8.0.0"
       }
@@ -1290,13 +1290,12 @@
       }
     },
     "node_modules/passport": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/passport/-/passport-0.7.0.tgz",
-      "integrity": "sha512-cPLl+qZpSc+ireUvt+IzqbED1cHHkDoVYMo30jbJIdOOjQ1MQYZBPiNvmi8UM6lJuOpTPXJGZQk0DtC4y61MYQ==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/passport/-/passport-0.5.3.tgz",
+      "integrity": "sha512-gGc+70h4gGdBWNsR3FuV3byLDY6KBTJAIExGFXTpQaYfbbcHCBlRRKx7RBQSpqEqc5Hh2qVzRs7ssvSfOpkUEA==",
       "dependencies": {
         "passport-strategy": "1.x.x",
-        "pause": "0.0.1",
-        "utils-merge": "^1.0.1"
+        "pause": "0.0.1"
       },
       "engines": {
         "node": ">= 0.4.0"

--- a/server/package.json
+++ b/server/package.json
@@ -17,7 +17,7 @@
     "express-session": "^1.17.3",
     "mongodb": "^6.3.0",
     "mongoose": "^8.0.2",
-    "passport": "^0.7.0",
+    "passport": "^0.5.3",
     "passport-local": "^1.0.0",
     "passport-local-mongoose": "^8.0.0"
   }

--- a/server/routes/routes.js
+++ b/server/routes/routes.js
@@ -11,7 +11,7 @@ router.post('/signup', authController.postSignup)
 // post route to auth to log in
 router.post('/login', authController.postLogin)
 // post route to auth to sign out
-// router.post('/logout', authController.postLogout)
+router.post('/logout', authController.postLogout)
 
 
 // formdata to submit a new form

--- a/server/server.js
+++ b/server/server.js
@@ -22,9 +22,13 @@ const corsOptions = {
 
 app.use(cors(corsOptions))
 
+// app.use(cors())
+
 // Body parsing
 app.use(express.json())
 app.use(express.urlencoded({ extended: true }));
+
+
 
 // Setup sessions stored in mongodb
 app.use(


### PR DESCRIPTION
set up the post request to log out but running into problems with the implentation of the postLogout controller in authcontroller

  postLogout: (req, res) => {
    // console.log(req)
    // res.send('hey back')
    console.log('inside logout')
    console.log('before logout - req.session:', req.session)
    try{
      req.logout(() => {
        console.log('User has logged out')
        console.log('after logout - req.session:', req.session)
      
        req.session.destroy((err) => {
          if(err){
            console.log('Error: Failed to destory the session during logout', err)
          }
          req.user = null

          res.status(200).send('User logged out')

        })
      })

    }catch(err){
      console.error('error during logout:', err)
      res.status(500).send('Internal Server Error')
    }
  }
}

right now i had to downgrade the passport package to 0.5.3 instead of most recent 0.7.0 

when i tried to destroy the session on log out it would throw an error described by others here
https://stackoverflow.com/questions/50454992/req-session-destroy-and-passport-logout-arent-destroying-cookie-on-client-side
and here
https://github.com/jaredhanson/passport/issues/907

i might be misunderstanding how logout works but i think i will move on to the next part because i believe users can log in and need to come back to the logout bug later

